### PR TITLE
feat: pass context to boilerplate install scripts

### DIFF
--- a/src/cmds/create/index.ts
+++ b/src/cmds/create/index.ts
@@ -19,7 +19,7 @@ export const describe = 'Bootstrap a new GraphQL project'
 export const builder = {
   boilerplate: {
     alias: 'b',
-    describe: 'URL to boilerplate GitHub repostiory',
+    describe: 'Full URL or repo shorthand (e.g. `owner/repo`) to boilerplate GitHub repository',
     type: 'string',
   },
   'no-install': {
@@ -35,7 +35,8 @@ function getGitHubUrl(
   const details = gh(boilerplate)
 
   if (details.host && details.owner && details.repo) {
-    return `https://${details.host}/${details.repo}`
+    const branch = details.branch ? `/tree/${details.branch}` : ''
+    return `https://${details.host}/${details.repo}${branch}`
   }
 }
 
@@ -170,7 +171,7 @@ export async function handler(
     console.log(`[graphql create] Running boilerplate install script... `)
     const installFunction = require(installPath)
 
-    await installFunction({ project: directory })
+    await installFunction({ context, project: directory })
 
     fs.unlinkSync(installPath)
   }


### PR DESCRIPTION
- pass the `context` object to boilerplate install scripts
- add support for branches in shorthand (e.g. `owner/repo#branch`)

By passing the context, we're able to use the `prompt` in install commands, which will allow boilerplate creators to do more customized installs — for example, in a GrAMPS data source, this will allow setting global values such as the type prefix, data source namespace, and other values that are easy to update programmatically.

For testing, you can try this:

```bash
graphql create -b gramps-graphql/data-source-base#gql-cli-install data-source-test
```