### PR TITLE
Update some links and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can see it in action here:
 
 ![demo](http://imgur.com/0kuqZFY.gif)
 
-> Note: The `graphql-cli` has a different use case than the [Graphcool CLI](https://docs-next.graph.cool/reference/graphcool-cli/overview-zboghez5go). Read more about the differences [here](https://docs-next.graph.cool/faq/other-reob2ohph7/#whats-the-difference-between-the-graphcool-cli-and-the-graphql-cli).
+> Note: The `graphql-cli` has a different use case than the [Graphcool CLI](https://www.graph.cool/docs/reference/graphcool-cli/overview-zboghez5go/). Graphcool CLI is specific to the Graphcool Framework, while `graphql-cli` can be used with any GraphQL project.
 
 ## Install
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -28,7 +28,7 @@ installCommands()
   .alias('h', 'help')
   .alias('v', 'version')
   .epilogue(
-    'For more information go to https://github.com/graphcool/graphql-cli',
+    'For more information go to https://github.com/graphql-cli/graphql-cli',
   )
   .fail((msg, err, yargs) => {
     if (err) throw err // preserve stack


### PR DESCRIPTION
* The tool linked to `https://github.com/graphcool/graphql-cli`, which doesn't exist (though maybe it once did). Now it links to this repo.
* The link to the Graphcool CLI didn't work, so I changed it to one that does.
* I couldn't find a working link that describes the difference between graphql-cli and Graphcool CLI, so I took the answer [here](https://github.com/graphcool/framework/blob/master/docs/0.x/05-FAQ/06-Other.md)  and paraphrased, removing the link