### PR TITLE
--json requires --output

### DIFF
--- a/src/cmds/get-schema.ts
+++ b/src/cmds/get-schema.ts
@@ -67,6 +67,7 @@ const command: CommandObject = {
       })
       .implies('console', ['--no-output', '--no-watch'])
       .implies('all', ['--no-output', '--no-endpoint', '--no-project'])
+      .implies('json', 'output')
       .implies('--no-endpoint', '--no-header'),
 
   handler: async (context: Context, argv: Arguments) => {


### PR DESCRIPTION
Running `graphql get-schema --json` without an output filename results in a cryptic error:

> path must be a string or Buffer

This updates the code to require `--output` if `--json` is given.