### PR TITLE
Fix hooks experience in CLI

### DIFF
--- a/src/cmds/get-schema.ts
+++ b/src/cmds/get-schema.ts
@@ -220,7 +220,7 @@ async function updateSingleProjectEndpoint(
     } catch (e) {
       // ignore error if no previous schema file existed
       if (e.message === 'Unsupported schema file extention. Only ".graphql" and ".json" are supported') {
-        log(chalk.red(e.message))
+        console.error(e.message)
         setTimeout(() => {
           process.exit(1)
         }, 500)

--- a/src/cmds/get-schema.ts
+++ b/src/cmds/get-schema.ts
@@ -219,6 +219,12 @@ async function updateSingleProjectEndpoint(
         : config!.getSchemaSDL()
     } catch (e) {
       // ignore error if no previous schema file existed
+      if (e.message === 'Unsupported schema file extention. Only ".graphql" and ".json" are supported') {
+        log(chalk.red(e.message))
+        setTimeout(() => {
+          process.exit(1)
+        }, 500)
+      }
       if (e.code !== 'ENOENT') {
         throw e
       }


### PR DESCRIPTION
This is meant to be a helper PR of https://github.com/prismagraphql/prisma/pull/2562

1. Failure of get-schema command must result in a non-zero exit status code and write to `stderr`