### PR TITLE
fix(get-schema): if endpoint is provided, ignore all

### DIFF
--- a/src/cmds/get-schema.ts
+++ b/src/cmds/get-schema.ts
@@ -70,11 +70,14 @@ const command: CommandObject = {
         },
       })
       .implies('console', ['--no-output', '--no-watch'])
-      .implies('all', ['--no-output', '--no-endpoint'])
       .implies('json', 'output')
       .implies('--no-endpoint', '--no-header'),
 
   handler: async (context: Context, argv: Arguments) => {
+    if (argv.endpoint) {
+      argv.all = false
+    }
+
     if (argv.all && !argv.project) {
       argv.project = argv.endpoint = '*'
     }


### PR DESCRIPTION
Fixes #299

If both `--endpoint` and `--all` is specified, we ignore `--all` silently. This is because `--all` is activated by default.

