### PR TITLE
Fix skipped endpoints bug in get-schema

### DIFF
--- a/src/cmds/get-schema.ts
+++ b/src/cmds/get-schema.ts
@@ -170,7 +170,7 @@ async function update(context: Context, argv: Arguments) {
   for (const projectName in projects) {
     const config = projects[projectName]
     if (!config.endpointsExtension) {
-      return
+      continue
     }
     const endpoints = getEndpoints(config, argv)
     for (const endpointName in endpoints) {


### PR DESCRIPTION
If a project inside the config does not have endpoints, then all subsequent projects would be silently skipped because this `update()` function would return rather than continuing the loop to the next project.